### PR TITLE
Fixed NEXT_REDIRECT error in server actions during authentication

### DIFF
--- a/app/lib/actions.js
+++ b/app/lib/actions.js
@@ -158,8 +158,12 @@ export const authenticate = async (prevState, formData) => {
   const { username, password } = Object.fromEntries(formData);
 
   try {
-    await signIn("credentials", { username, password });
+    // Disable redirect
+    await signIn("credentials", { username, password, redirect: false });
   } catch (err) {
     return "Wrong Credentials!";
   }
+  
+  // Redirect to dashboard here
+  redirect("/dashboard");
 };


### PR DESCRIPTION
In lib/actions.js, there is a try catch statement for signing in which automatically redirects but NextJS throws a NEXT_REDIRECT signal while redirecting which ends up getting caught in the authenticate function making the sign-in throw wrong creds error.

To resolve this problem, I have added the necessary changes which is to set the redirect to false and redirect manually outside the try-catch statement.